### PR TITLE
Improve Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ At this early brainstorming stage, the goals are:
 - **License:** MIT
 - **Build System:** Probably CMake, eventually
 
+## 🔧 Building
+
+To build on Windows you'll need [CMake](https://cmake.org/) and a make tool.
+Install either the Visual Studio Build Tools (providing `nmake`) or MinGW
+(`mingw32-make`). Running `build.bat` will pick the appropriate generator if one
+of those tools is on your `PATH`.
+
+To force a different generator, set the `generator` environment variable before
+invoking the script:
+
+```cmd
+set generator=Unix Makefiles
+build.bat
+```
+
 ## 🪦 Why?
 
 Why not? Life's already hard enough—why not simulate it in 80x24 characters?

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,18 @@
 @echo off
 REM Simple build script for Windows users
+
+REM Detect a suitable CMake generator when none is provided
+if not defined generator (
+    set "generator=NMake Makefiles"
+    where nmake >nul 2>nul
+    if errorlevel 1 (
+        where mingw32-make >nul 2>nul
+        if not errorlevel 1 set "generator=MinGW Makefiles"
+    )
+)
+
 if not exist build mkdir build
 cd build
-cmake -G "Unix Makefiles" ..
+cmake -G "%generator%" ..
 cmake --build .
 cd ..


### PR DESCRIPTION
## Summary
- update `build.bat` to detect `nmake` or `mingw32-make`
- document Windows build requirements and overriding the generator

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6843bcc654248320adbd7a93d373d054

## Summary by Sourcery

Add Windows build documentation to README and enhance build.bat to auto-detect or override the CMake generator

Enhancements:
- Auto-detect nmake or mingw32-make in build.bat to select the appropriate CMake generator
- Allow overriding the CMake generator by setting the ‘generator’ environment variable

Documentation:
- Add a Windows building section in README.md outlining requirements and usage