### PR TITLE
Add permadeath collisions and fancy IO

### DIFF
--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -1,0 +1,11 @@
+"""Utility functions for I/O operations."""
+
+
+def fprint(*args, **kwargs):
+    """Wrapper around built-in print for future enhancements."""
+    print(*args, **kwargs)
+
+
+def finput(prompt: str = "") -> str:
+    """Wrapper around built-in input for future enhancements."""
+    return input(prompt)

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 from npc import NPC
 from simulation import Simulation
+from io_utils import fprint, finput
 
 
 def main() -> None:
@@ -10,21 +11,21 @@ def main() -> None:
     sim.add_npc(friend)
 
     while True:
-        print("\n" + sim.time_str())
+        fprint("\n" + sim.time_str())
         for n in sim.npcs:
-            print(n.describe())
-        cmd = input("[a]dvance, [t]alk, [e]at, [s]leep, [q]uit > ").strip().lower()
+            fprint(n.describe())
+        cmd = finput("[a]dvance, [t]alk, [e]at, [s]leep, [q]uit > ").strip().lower()
         if cmd == "a":
             sim.tick()
         elif cmd == "t":
-            target_name = input("Talk to who? ")
+            target_name = finput("Talk to who? ")
             target = next((n for n in sim.npcs if n.name.lower() == target_name.lower()), None)
             if target and target is not player:
                 player.talk_to(target)
                 sim.tick()
-                print(f"You talked to {target.name}.")
+                fprint(f"You talked to {target.name}.")
             else:
-                print("No such NPC.")
+                fprint("No such NPC.")
         elif cmd == "e":
             player.eat()
             sim.tick()
@@ -34,7 +35,7 @@ def main() -> None:
         elif cmd == "q":
             break
         else:
-            print("Invalid command.")
+            fprint("Invalid command.")
 
 
 if __name__ == "__main__":

--- a/src/npc.py
+++ b/src/npc.py
@@ -8,9 +8,13 @@ class NPC:
         self.social = 50
         # Relationships with other NPCs by name
         self.relationships = {}
+        # Alive state for permadeath
+        self.alive = True
 
     def tick(self) -> None:
         """Simulate the passage of time for this NPC."""
+        if not self.alive:
+            return
         self.hunger = min(100, self.hunger + 10)
         self.energy = max(0, self.energy - 5)
         self.social = max(0, self.social - 2)
@@ -23,15 +27,44 @@ class NPC:
         """Restore energy."""
         self.energy = min(100, self.energy + 40)
 
+    def die(self) -> None:
+        """Mark NPC as dead permanently."""
+        self.alive = False
+
     def talk_to(self, other: "NPC") -> None:
-        """Improve relationship with another NPC."""
+        """Improve relationship with another NPC and get a generated reply."""
+        from io_utils import fprint
+        import requests
+
+        if not self.alive or not other.alive:
+            return
+
         if other.name not in self.relationships:
             self.relationships[other.name] = 0
         self.relationships[other.name] += 5
         self.social = min(100, self.social + 10)
 
+        fprint(f"{other.name} is thinking...")
+        prompt = f"Say something to {self.name}."
+        try:
+            resp = requests.post(
+                "https://text.pollinations.ai/openai",
+                json={"model": "openai-large", "prompt": prompt},
+                timeout=5,
+            )
+            if resp.ok:
+                data = resp.json()
+                message = data.get("choices", [{}])[0].get("text", "...").strip()
+            else:
+                message = "..."
+        except Exception:
+            message = "..."
+        fprint(f"{other.name}: {message}")
+
     def describe(self) -> str:
         """Return a short description of the NPC's current state."""
+        if not self.alive:
+            return f"{self.name} is dead."
         return (
             f"{self.name} ({self.age}) - "
             f"hunger:{self.hunger}% energy:{self.energy}% social:{self.social}%"

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -15,8 +15,15 @@ class Simulation:
         if self.hour >= 24:
             self.hour = 0
             self.day += 1
-        for npc in self.npcs:
+        from io_utils import fprint
+        import random
+
+        for npc in list(self.npcs):
             npc.tick()
+            if npc.alive and random.random() < 0.05:
+                npc.die()
+                fprint(f"{npc.name} died in a tragic collision!")
+                self.npcs = [n for n in self.npcs if n.alive]
 
     def time_str(self) -> str:
         return f"Day {self.day} Hour {self.hour:02d}"


### PR DESCRIPTION
## Summary
- route output through `io_utils` library
- integrate NPC dialogue with pollinations API using `openai-large`
- introduce permanent NPC death via random collisions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/main.py <<'EOF'
a
q
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6843c27642e08320b66c41630aaa4b60

## Summary by Sourcery

Add permanent NPC death on random collisions, integrate NPC dialogue with the Pollinations API, and centralize console I/O through utility wrappers

New Features:
- Enable permanent NPC death when collisions occur during simulation ticks
- Generate NPC dialogue via the Pollinations API with the openai-large model
- Route all console input and output through io_utils.fprint and io_utils.finput wrappers

Enhancements:
- Introduce an NPC.alive flag and die method to manage life state
- Prevent actions and descriptions for NPCs that have died
- Automatically remove deceased NPCs from the simulation after death

Chores:
- Add a new io_utils module to encapsulate I/O operations