### PR TITLE
Enable starvation death and persona-based chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ At this early brainstorming stage, the goals are:
 
 ## 🔧 Running
 
-The simulator no longer needs a separate build step. With Python installed,
-simply run:
+The simulator no longer needs a separate build step. Install dependencies and
+run:
 
 ```bash
+pip install -r requirements.txt
 python src/main.py
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -1,0 +1,11 @@
+"""Utility functions for I/O operations."""
+
+
+def fprint(*args, **kwargs):
+    """Wrapper around built-in print for future enhancements."""
+    print(*args, **kwargs)
+
+
+def finput(prompt: str = "") -> str:
+    """Wrapper around built-in input for future enhancements."""
+    return input(prompt)

--- a/src/main.py
+++ b/src/main.py
@@ -1,30 +1,32 @@
 from npc import NPC
 from simulation import Simulation
+from io_utils import fprint, finput
 
 
 def main() -> None:
     sim = Simulation()
-    player = NPC("Player", 25)
-    friend = NPC("Jamie", 28)
+    player = NPC("Player", 25, "A confused human trying to make sense of life.")
+    friend = NPC("Jamie", 28, "A friendly but quirky neighbor who loves trivia.")
     sim.add_npc(player)
     sim.add_npc(friend)
 
     while True:
-        print("\n" + sim.time_str())
+        fprint("\n" + sim.time_str())
         for n in sim.npcs:
-            print(n.describe())
-        cmd = input("[a]dvance, [t]alk, [e]at, [s]leep, [q]uit > ").strip().lower()
+            fprint(n.describe())
+        cmd = finput("[a]dvance, [t]alk, [e]at, [s]leep, [q]uit > ").strip().lower()
         if cmd == "a":
             sim.tick()
         elif cmd == "t":
-            target_name = input("Talk to who? ")
+            target_name = finput("Talk to who? ")
             target = next((n for n in sim.npcs if n.name.lower() == target_name.lower()), None)
             if target and target is not player:
-                player.talk_to(target)
+                question = finput("What do you ask? ")
+                player.talk_to(target, question)
                 sim.tick()
-                print(f"You talked to {target.name}.")
+                fprint(f"You talked to {target.name}.")
             else:
-                print("No such NPC.")
+                fprint("No such NPC.")
         elif cmd == "e":
             player.eat()
             sim.tick()
@@ -34,7 +36,7 @@ def main() -> None:
         elif cmd == "q":
             break
         else:
-            print("Invalid command.")
+            fprint("Invalid command.")
 
 
 if __name__ == "__main__":

--- a/src/npc.py
+++ b/src/npc.py
@@ -1,19 +1,26 @@
 class NPC:
-    def __init__(self, name: str, age: int):
+    def __init__(self, name: str, age: int, persona: str = ""):
         self.name = name
         self.age = age
+        self.persona = persona
         # Basic needs
         self.hunger = 0
         self.energy = 100
         self.social = 50
         # Relationships with other NPCs by name
         self.relationships = {}
+        # Alive state for permadeath
+        self.alive = True
 
     def tick(self) -> None:
         """Simulate the passage of time for this NPC."""
+        if not self.alive:
+            return
         self.hunger = min(100, self.hunger + 10)
         self.energy = max(0, self.energy - 5)
         self.social = max(0, self.social - 2)
+        if self.hunger >= 100:
+            self.die()
 
     def eat(self) -> None:
         """Restore some hunger."""
@@ -23,15 +30,44 @@ class NPC:
         """Restore energy."""
         self.energy = min(100, self.energy + 40)
 
-    def talk_to(self, other: "NPC") -> None:
-        """Improve relationship with another NPC."""
+    def die(self) -> None:
+        """Mark NPC as dead permanently."""
+        self.alive = False
+
+    def talk_to(self, other: "NPC", question: str) -> None:
+        """Ask another NPC a question and show their persona-based answer."""
+        from io_utils import fprint
+        import requests
+
+        if not self.alive or not other.alive:
+            return
+
         if other.name not in self.relationships:
             self.relationships[other.name] = 0
         self.relationships[other.name] += 5
         self.social = min(100, self.social + 10)
 
+        fprint(f"{other.name} is thinking...")
+        prompt = f"{other.persona}\nQ: {question}\nA:"
+        try:
+            resp = requests.post(
+                "https://text.pollinations.ai/openai",
+                json={"model": "openai-large", "prompt": prompt},
+                timeout=5,
+            )
+            if resp.ok:
+                data = resp.json()
+                message = data.get("choices", [{}])[0].get("text", "...").strip()
+            else:
+                message = "..."
+        except Exception:
+            message = "..."
+        fprint(f"{other.name}: {message}")
+
     def describe(self) -> str:
         """Return a short description of the NPC's current state."""
+        if not self.alive:
+            return f"{self.name} is dead."
         return (
             f"{self.name} ({self.age}) - "
             f"hunger:{self.hunger}% energy:{self.energy}% social:{self.social}%"

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -15,8 +15,14 @@ class Simulation:
         if self.hour >= 24:
             self.hour = 0
             self.day += 1
-        for npc in self.npcs:
+        from io_utils import fprint
+
+        for npc in list(self.npcs):
+            before_alive = npc.alive
             npc.tick()
+            if before_alive and not npc.alive:
+                fprint(f"{npc.name} starved to death!")
+                self.npcs = [n for n in self.npcs if n.alive]
 
     def time_str(self) -> str:
         return f"Day {self.day} Hour {self.hour:02d}"


### PR DESCRIPTION
## Summary
- add dependency requirements file
- update README run instructions
- NPCs accept persona strings and can starve to death
- Simulation reports starvation deaths
- player can ask NPCs questions and get persona-based replies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/main.py <<'EOF'
a
q
EOF`
- `python src/main.py <<'EOF'
t
Jamie
What do you like?
q
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6843c27642e08320b66c41630aaa4b60

## Summary by Sourcery

Enable persona-based NPC conversations and starvation mechanics, integrate an external API for responses, add I/O utility wrappers, and set up dependency management via requirements.txt.

New Features:
- Add persona strings to NPCs for customized behavior
- Enable NPCs to starve to death and be removed from the simulation
- Allow the player to ask NPCs questions and receive persona-based replies via an external API

Enhancements:
- Introduce fprint and finput I/O wrappers for future extensibility

Build:
- Add requirements.txt to manage external dependencies

Documentation:
- Update README to include instructions for installing dependencies