### PR TITLE
Add Pollinations GET option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ pip install -r requirements.txt
 python src/main.py
 ```
 
+### Chat responses
+
+NPC dialogue uses the free Pollinations API. By default it posts to the
+OpenAI-compatible endpoint, but you can switch to the simpler GET API:
+
+```python
+from chat_service import ChatService
+service = ChatService(use_get=True)
+```
+
+This packs the persona and question into a single URL request like
+`https://text.pollinations.ai/{persona} Q: {question} A:`.
+
 ## 🪦 Why?
 
 Why not? Life's already hard enough—why not simulate it in 80x24 characters?

--- a/src/chat_service.py
+++ b/src/chat_service.py
@@ -1,14 +1,33 @@
 class ChatService:
-    """Client for interacting with the Pollinations Chat Completions API."""
+    """Client for interacting with the Pollinations text APIs."""
 
-    def __init__(self, endpoint: str = "https://text.pollinations.ai/openai", model: str = "openai-large", timeout: int = 5):
+    def __init__(
+        self,
+        endpoint: str = "https://text.pollinations.ai/openai",
+        model: str = "openai-large",
+        timeout: int = 5,
+        use_get: bool = False,
+    ):
         self.endpoint = endpoint
         self.model = model
         self.timeout = timeout
+        self.use_get = use_get
 
     def ask(self, persona: str, question: str) -> str:
         """Send the persona and question to the API and return the response."""
         import requests
+        import urllib.parse
+
+        if self.use_get:
+            prompt = f"{persona} Q: {question} A:"
+            url = f"https://text.pollinations.ai/{urllib.parse.quote(prompt)}"
+            try:
+                resp = requests.get(url, timeout=self.timeout)
+                if resp.ok:
+                    return resp.text.strip()
+            except Exception:
+                pass
+            return "..."
 
         payload = {
             "model": self.model,


### PR DESCRIPTION
## Summary
- enable Pollinations simple GET API in `ChatService`
- document the new feature in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6843cb4570fc83209f9407780e682d35