### PR TITLE
Add settings to switch APIs

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -17,12 +17,18 @@ Welcome to the absolute mess that is **grep-purpose**'s internal design. This fi
 
 ## 💬 NPC Dialogue (Or, “Why Is My Sim Quoting Schopenhauer?”)
 
-NPCs try to be relatable by talking to the [Pollinations API](https://text.pollinations.ai/). By default, `ChatService` uses the OpenAI-compatible endpoint, but if you enjoy living on the edge, you can use the jankier GET API:
+NPCs try to be relatable by talking to the [Pollinations API](https://text.pollinations.ai/). The simpler GET API is now the default because the OpenAI-compatible endpoint is a bit broken. If you want to try the OpenAI flavor anyway, pass `use_get=False` or toggle it in the TUI settings:
 
 ```python
 from chat_service import ChatService
-service = ChatService(use_get=True)
-````
+service = ChatService()  # uses the GET API by default
+```
+
+Need to feel brave? Use the OpenAI endpoint instead:
+
+```python
+service = ChatService(use_get=False)
+```
 
 This will squish both the persona and the burning question into a single GET request, like:
 

--- a/src/chat_service.py
+++ b/src/chat_service.py
@@ -6,7 +6,7 @@ class ChatService:
         endpoint: str = "https://text.pollinations.ai/openai",
         model: str = "openai-large",
         timeout: int = 5,
-        use_get: bool = False,
+        use_get: bool = True,
     ):
         self.endpoint = endpoint
         self.model = model

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ def main() -> None:
         fprint("\n" + sim.time_str())
         for n in sim.npcs:
             fprint(n.describe())
-        cmd = finput("[a]dvance, [t]alk, [e]at, [s]leep, [q]uit > ").strip().lower()
+        cmd = finput("[a]dvance, [t]alk, [e]at, [s]leep, [o]ptions, [q]uit > ").strip().lower()
         if cmd == "a":
             sim.tick()
         elif cmd == "t":
@@ -35,6 +35,16 @@ def main() -> None:
         elif cmd == "s":
             player.sleep()
             sim.tick()
+        elif cmd == "o":
+            choice = finput("Use GET API or OpenAI? [g/o] > ").strip().lower()
+            if choice == "g":
+                chat_service.use_get = True
+                fprint("Using GET API.")
+            elif choice == "o":
+                chat_service.use_get = False
+                fprint("Using OpenAI-compatible API.")
+            else:
+                fprint("Invalid option.")
         elif cmd == "q":
             break
         else:


### PR DESCRIPTION
## Summary
- allow toggling between GET and OpenAI Pollinations API from the options menu
- default `ChatService` to GET API
- document the default API change in **INTERNALS.md**

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6843cddd0a3083208ce9d2717a33bccc

## Summary by Sourcery

Allow users to switch the ChatService API at runtime via the options menu, defaulting to the GET endpoint and updating documentation to reflect this change

New Features:
- Add an in-app option in the TUI to toggle between the GET and OpenAI-compatible APIs

Enhancements:
- Default `ChatService` to use the simpler GET API instead of the OpenAI-compatible endpoint

Documentation:
- Update INTERNALS.md to reflect the new default API and document how to switch between endpoints