### PR TITLE
Add log waits after user actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 
 ---
 
-## v0.6.13-alpha~regret@caffeine  
-### #13 - Add NPC money and new places  
+## v0.6.13-alpha~regret@caffeine
+### #13 - Add NPC money and new places
 NPCs now live in a hell-economy. Money is tracked. Places exist. Both are probably meaningless.
+
+## v0.6.14-alpha~logger@waiting
+### #14 - Block until API log line
+Every user action now triggers a Pollinations GET call that writes a short narrative line to `log.txt`. The game waits for this line before asking for the next command.
 
 ## v0.6.12-alpha~confusion@fridaynight  
 ### #12 - Add settings to switch APIs  

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,17 @@ from io_utils import fprint, finput, cls
 from chat_service import ChatService
 
 
+def log_action(chat_service: ChatService, npc: NPC, action: str) -> None:
+    """Generate a log line via Pollinations and append to log.txt."""
+    prompt = (
+        f"Write one short sentence describing how {npc.name} {action}. "
+        f"Stats: hunger {npc.hunger} energy {npc.energy} social {npc.social} money {npc.money}."
+    )
+    line = chat_service.ask(npc.persona or "Narrator", prompt)
+    with open("log.txt", "a", encoding="utf-8") as log_file:
+        log_file.write(line + "\n")
+
+
 def main() -> None:
     sim = Simulation()
     chat_service = ChatService()
@@ -20,6 +31,7 @@ def main() -> None:
         cmd = finput("[a]dvance, [t]alk, [e]at, [s]leep, [o]ptions, [q]uit > ").strip().lower()
         if cmd == "a":
             sim.tick()
+            log_action(chat_service, player, "watched time pass")
         elif cmd == "t":
             target_name = finput("Talk to who? ")
             target = next((n for n in sim.npcs if n.name.lower() == target_name.lower()), None)
@@ -28,14 +40,17 @@ def main() -> None:
                 player.talk_to(target, question, chat_service)
                 sim.tick()
                 fprint(f"You talked to {target.name}.")
+                log_action(chat_service, target, f"chatted with {player.name}")
             else:
                 fprint("No such NPC.")
         elif cmd == "e":
             player.eat()
             sim.tick()
+            log_action(chat_service, player, "ate")
         elif cmd == "s":
             player.sleep()
             sim.tick()
+            log_action(chat_service, player, "slept")
         elif cmd == "o":
             choice = finput("Use GET API or OpenAI? [g/o] > ").strip().lower()
             if choice == "g":


### PR DESCRIPTION
## Summary
- append a Pollinations-generated log line after each user command
- block for the log line before continuing the game
- document the new logging behavior in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d2956630832090b1b83e577373db

## Summary by Sourcery

Introduce narrative logging for each user action by calling Pollinations API, appending the result to log.txt, and pausing the game until the log entry is written

New Features:
- Generate and append a Pollinations API narrative line to log.txt after each user action, blocking until it is received

Enhancements:
- Add a log_action helper and integrate it into advance, talk, eat, and sleep commands

Documentation:
- Document the new blocking logging behavior in CHANGELOG under v0.6.14